### PR TITLE
Feat/add has slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import { defineSlots, type Slottable } from "named-slots";
 
 export const Card = ({ children }: { children: Slottable }) => {
   type CardSlots = "header" | "content" | "footer";
-  const Slot =
+  const { Slot } =
     defineSlots <
     CardSlots >
     (children, ["header", "content", "footer"], { inComponent: Card, throws: true });

--- a/frameworks/preact/src/DefinedCard.tsx
+++ b/frameworks/preact/src/DefinedCard.tsx
@@ -1,11 +1,13 @@
-import { defineSlots, type Slottable } from "named-slots";
+import { defineSlots, type Slottable } from "../../../src/Slot";
 
 export const DefinedCard = ({ children }: { children: Slottable }) => {
-  const Slot = defineSlots<"header" | "content" | "footer">(children, [
-    "header",
-    "content",
-    "footer",
-  ]);
+  const { Slot, hasSlot } = defineSlots<"header" | "content" | "footer">(
+    children,
+    ["header", "content", "footer"]
+  );
+
+  const hasContent = hasSlot("content");
+  console.log("DefinedCard has content?", hasContent);
 
   return (
     <div className={"card"}>

--- a/frameworks/react/src/Card.tsx
+++ b/frameworks/react/src/Card.tsx
@@ -1,6 +1,5 @@
 import { Slot, validateSlots, type Slottable } from "named-slots";
 
-// export default class Welcome extends React.Component {
 export const Card = ({ children }: { children: Slottable }) => {
   validateSlots(children, ["header", "content", "footer"], {
     inComponent: Card,

--- a/frameworks/react/src/DefinedCard.tsx
+++ b/frameworks/react/src/DefinedCard.tsx
@@ -1,12 +1,13 @@
-import { defineSlots, type Slottable } from "named-slots";
+import { defineSlots, type Slottable } from "../../../src/Slot";
 
-// export default class Welcome extends React.Component {
 export const DefinedCard = ({ children }: { children: Slottable }) => {
-  const Slot = defineSlots<"header" | "content" | "footer">(children, [
-    "header",
-    "content",
-    "footer",
-  ]);
+  const { Slot, hasSlot } = defineSlots<"header" | "content" | "footer">(
+    children,
+    ["header", "content", "footer"]
+  );
+
+  const hasContent = hasSlot("content");
+  console.log("DefinedCard has content?", hasContent);
 
   return (
     <div className={"card"}>

--- a/frameworks/solid/src/DefinedCard.tsx
+++ b/frameworks/solid/src/DefinedCard.tsx
@@ -1,11 +1,13 @@
-import { Slottable, defineSlots } from "named-slots/solid";
+import { Slottable, defineSlots } from "../../../src/solid/Slot";
 
 export const DefinedCard = ({ children }: { children: Slottable }) => {
-  const Slot = defineSlots<"header" | "content" | "footer">(children, [
-    "header",
-    "content",
-    "footer",
-  ]);
+  const { Slot, hasSlot } = defineSlots<"header" | "content" | "footer">(
+    children,
+    ["header", "content", "footer"]
+  );
+
+  const hasContent = hasSlot("content");
+  console.log("DefinedCard has content?", hasContent);
 
   return (
     <div class={"card"}>

--- a/src/Slot.tsx
+++ b/src/Slot.tsx
@@ -20,12 +20,16 @@ const getSlot = <T extends unknown = string>({
   return slot ?? fallback;
 };
 
+const slotExists = <T extends unknown = string>(name: T, from: Slottable) => {
+  const slotted = Array.isArray(from) ? from : [from];
+  return slotted.some((el) => el.props?.slot === name);
+};
+
 /**
  * Named slot component. Renders the first child with a matching slot attribute.
  * @param {string} name - The name of the slot to render.
  * @param {any} children - The fallback content to render if no matching slot is found.
  * @param {Slottable} from - The children to search for the slot.
- * @returns {any} The matching slot or the fallback content.
  */
 export const Slot = <T extends unknown = string>({
   name,
@@ -89,7 +93,6 @@ type DefinedSlot<T = string> = Omit<Slot<T>, "from">;
  * @param children children of component where Slot is used
  * @param slotNames names of Slots used in the component
  * @param options additional options for better debugging
- * @returns {Slot} Slot component
  */
 export const defineSlots = <T extends unknown = string>(
   children: Slottable,
@@ -98,8 +101,12 @@ export const defineSlots = <T extends unknown = string>(
 ) => {
   validateSlots(children, slotNames, options ?? {});
   // closure over children
-  return ({ name, children: fallback }: DefinedSlot<T>) =>
+  const Slot = ({ name, children: fallback }: DefinedSlot<T>) =>
     getSlot<T>({ name, children: fallback, from: children });
+
+  const hasSlot = (name: T) => slotExists<T>(name, children);
+
+  return { Slot, hasSlot };
 };
 
 // @ts-ignore-error preact not present

--- a/src/solid/Slot.tsx
+++ b/src/solid/Slot.tsx
@@ -19,12 +19,16 @@ const getSlot = <T extends unknown = string>({
   return slot ?? fallback;
 };
 
+const slotExists = <T extends unknown = string>(name: T, from: Slottable) => {
+  const slotted = Array.isArray(from) ? from : [from];
+  return slotted.some((el) => el.getAttribute("slot") === name);
+};
+
 /**
  * Named slot component. Renders the first child with a matching slot attribute.
  * @param {string} name - The name of the slot to render.
  * @param {any} children - The fallback content to render if no matching slot is found.
  * @param {Slottable} from - The children to search for the slot.
- * @returns {any} The matching slot or the fallback content.
  */
 export const Slot = <T extends unknown = string>({
   name,
@@ -97,6 +101,10 @@ export const defineSlots = <T extends unknown = string>(
 ) => {
   validateSlots(children, slotNames, options ?? {});
   // closure over children
-  return ({ name, children: fallback }: DefinedSlot<T>) =>
+  const Slot = ({ name, children: fallback }: DefinedSlot<T>) =>
     getSlot<T>({ name, children: fallback, from: children });
+
+  const hasSlot = (name: T) => slotExists<T>(name, children);
+
+  return { Slot, hasSlot };
 };


### PR DESCRIPTION
In certain cases consumers would like to know if a slot exists, to conditionally render it.

This introduces a `hasSlot` option to determine that.
```ts
const { Slot, hasSlot } = defineSlots<"header" | "footer">(children, ["header", "footer"]);

const hasFooter = hasSlot("footer");
```


This cannot be nicely done from the consumer side.

This does exists in other frameworks (eg: `v-if="$slots.header"` in Vue3).

BREAKING CHANGE: the API of defineSlots changed, needs bump to 0.4.0